### PR TITLE
ci: remove tests on Go 1.16

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x, 1.18.x, 1.19.x, 1.20.x]
+        go-version: [1.17.x, 1.18.x, 1.19.x, 1.20.x]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The minimal required Go version specified in go.mod is Go 1.17. So only run tests in CI environment for Go 1.17 and newer.