### PR TITLE
initramfs: copy args slice

### DIFF
--- a/initramfs/initramfs.go
+++ b/initramfs/initramfs.go
@@ -66,7 +66,7 @@ func (b *Bluebox) Execute(executable string, args ...string) error {
 		return fmt.Errorf("%s should not be a directory", executable)
 	}
 
-	b.execs[executable] = args[:]
+	b.execs[executable] = append([]string{}, args...)
 
 	return nil
 }


### PR DESCRIPTION
Use append([]string,...) to create a proper copy so the stored slice is not affected if the caller modifies the original.