### PR TITLE
initramfs: restrict permissions on generated Go source files

### DIFF
--- a/initramfs/init.go
+++ b/initramfs/init.go
@@ -13,7 +13,7 @@ import (
 
 // createInit writes a Go program and compiles it so it can be used as init.
 func (b *Bluebox) createInit(dir string) error {
-	f, err := os.OpenFile(filepath.Join(dir, "init.go"), os.O_CREATE|os.O_WRONLY, 0o644)
+	f, err := os.OpenFile(filepath.Join(dir, "init.go"), os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func (b *Bluebox) createInit(dir string) error {
 // createBluebox writes a Go program and compiles it. In a sequential order it will execute
 // the given execs with their respective args.
 func (b *Bluebox) createBluebox(tmpDir string) error {
-	f, err := os.OpenFile(filepath.Join(tmpDir, "bluebox.go"), os.O_CREATE|os.O_WRONLY, 0o644)
+	f, err := os.OpenFile(filepath.Join(tmpDir, "bluebox.go"), os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to create temporary file: %v", err)
 	}


### PR DESCRIPTION
The generated Go files may embed environment variable values, passed via -v. On a shared machine with a world-readable TMPDIR, 0o644 would expose these values to other users. Therefore, restrict permission of these files to 0o600.